### PR TITLE
feat: add dark-mode frontend with analytics

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,115 +1,36 @@
-
 <!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Habit Tracker</title>
-
-  <!-- cal-heatmap CSS -->
-  <link
-    href="https://cdn.jsdelivr.net/npm/cal-heatmap@4.4.0/cal-heatmap.css"
-    rel="stylesheet"
-  />
-  <style>
-    body {
-      font-family: Arial, sans-serif;
-      margin: 20px;
-    }
-    #habitList {
-      margin-top: 10px;
-      list-style: none;
-      padding-left: 0;
-    }
-    #habitList li {
-      padding: 4px 0;
-    }
-    #habit-heatmap {
-      margin-top: 40px;
-    }
-  </style>
+  <link rel="stylesheet" href="styles.css" />
+  <link href="https://cdn.jsdelivr.net/npm/cal-heatmap@4.4.0/cal-heatmap.css" rel="stylesheet" />
 </head>
 <body>
-  <h1>My Habits</h1>
-  <button onclick="loadHabits()">Load Habits</button>
-  <ul id="habitList"></ul>
+  <header>
+    <h1>Habit Tracker Dashboard</h1>
+  </header>
+  <main>
+    <section class="habits">
+      <button id="loadHabits">Load Habits</button>
+      <ul id="habitList"></ul>
+    </section>
 
-  <h2>Habit Completion Heatmap</h2>
-  <div id="habit-heatmap"></div>
+    <section class="analytics">
+      <h2>Daily Success Rate</h2>
+      <div id="habit-heatmap"></div>
+      <canvas id="successChart"></canvas>
+    </section>
 
-  <!-- cal-heatmap JS -->
+    <section class="analytics">
+      <h2>Habit Success Rates</h2>
+      <canvas id="habitChart"></canvas>
+    </section>
+  </main>
+
   <script src="https://cdn.jsdelivr.net/npm/cal-heatmap@4.4.0/cal-heatmap.min.js"></script>
-  <script>
-    // Load habit list from backend
-    function loadHabits() {
-      fetch('http://localhost:5050/users/1/habits')
-        .then(response => response.json())
-        .then(data => {
-          const list = document.getElementById('habitList');
-          list.innerHTML = ''; // clear previous results
-          data.forEach(habit => {
-            const li = document.createElement('li');
-            li.textContent = habit.name;
-            list.appendChild(li);
-          });
-        })
-        .catch(err => {
-          console.error('Error loading habits:', err);
-        });
-    }
-
-    // Load and render heatmap of habit completion scores
-    function loadHeatmap() {
-      const cal = new CalHeatmap();
-
-      fetch("http://localhost:5050/users/1/scores")
-        .then(res => res.json())
-        .then(data => {
-          // Format data for cal-heatmap: keys are unix timestamps in seconds, values are intensity levels
-          const formatted = {};
-          data.forEach(entry => {
-            const timestamp = new Date(entry.date).getTime() / 1000;
-            // Map your score to heatmap intensity: 1 = no activity, 3 = full completion
-            formatted[timestamp] = entry.score === 1 ? 3 : (entry.score === 0 ? 2 : 1);
-          });
-
-          cal.paint({
-            itemSelector: "#habit-heatmap",
-            range: 12,
-            domain: {
-              type: "month",
-              gutter: 4
-            },
-            subDomain: {
-              type: "day",
-              radius: 4,
-              width: 20,
-              height: 20,
-            },
-            data: {
-              source: formatted,
-              type: "json"
-            },
-            scale: {
-              color: {
-                type: "linear",
-                domain: [1, 3],
-                range: ["#ebedf0", "#30a14e"] // GitHub-style colors
-              }
-            },
-            tooltip: true,
-          });
-        })
-        .catch(err => {
-          console.error('Error loading heatmap data:', err);
-        });
-    }
-
-    // Load heatmap on page load
-    window.onload = () => {
-      loadHeatmap();
-    };
-  </script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+  <script src="script.js"></script>
 </body>
 </html>
-

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -1,0 +1,101 @@
+const API_BASE = 'http://localhost:5050';
+const USER_ID = 1; // Placeholder user ID
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.getElementById('loadHabits').addEventListener('click', loadHabits);
+  loadHeatmap();
+  loadHabitSuccess();
+});
+
+function loadHabits() {
+  fetch(`${API_BASE}/users/${USER_ID}/habits`)
+    .then((response) => response.json())
+    .then((data) => {
+      const list = document.getElementById('habitList');
+      list.innerHTML = '';
+      data.forEach((habit) => {
+        const li = document.createElement('li');
+        li.textContent = habit.name;
+        list.appendChild(li);
+      });
+    })
+    .catch((err) => console.error('Error loading habits:', err));
+}
+
+function loadHeatmap() {
+  const cal = new CalHeatmap();
+  fetch(`${API_BASE}/users/${USER_ID}/success-log`)
+    .then((res) => res.json())
+    .then((data) => {
+      const formatted = {};
+      data.forEach((entry) => {
+        const timestamp = new Date(entry.date).getTime() / 1000;
+        formatted[timestamp] = entry.success_rate;
+      });
+      cal.paint({
+        itemSelector: '#habit-heatmap',
+        range: 12,
+        domain: { type: 'month', gutter: 4 },
+        subDomain: { type: 'day', radius: 4, width: 20, height: 20 },
+        data: { source: formatted, type: 'json' },
+        scale: {
+          color: { type: 'linear', domain: [0, 100], range: ['#3a3a3a', '#81c784'] },
+        },
+        tooltip: true,
+      });
+
+      const ctx = document.getElementById('successChart').getContext('2d');
+      new Chart(ctx, {
+        type: 'line',
+        data: {
+          labels: data.map((d) => d.date),
+          datasets: [
+            {
+              label: 'Daily Success Rate (%)',
+              data: data.map((d) => d.success_rate),
+              borderColor: '#1e88e5',
+              backgroundColor: 'rgba(30, 136, 229, 0.2)',
+              tension: 0.2,
+            },
+          ],
+        },
+        options: {
+          scales: {
+            x: { ticks: { color: '#e0e0e0' }, grid: { color: '#333' } },
+            y: { ticks: { color: '#e0e0e0' }, grid: { color: '#333' } },
+          },
+          plugins: { legend: { labels: { color: '#e0e0e0' } } },
+        },
+      });
+    })
+    .catch((err) => console.error('Error loading heatmap data:', err));
+}
+
+function loadHabitSuccess() {
+  fetch(`${API_BASE}/users/${USER_ID}/habits/success`)
+    .then((res) => res.json())
+    .then((data) => {
+      const ctx = document.getElementById('habitChart').getContext('2d');
+      new Chart(ctx, {
+        type: 'bar',
+        data: {
+          labels: data.map((h) => h.name),
+          datasets: [
+            {
+              label: 'Success Rate (%)',
+              data: data.map((h) => h.success_rate),
+              backgroundColor: '#1e88e5',
+            },
+          ],
+        },
+        options: {
+          scales: {
+            x: { ticks: { color: '#e0e0e0' }, grid: { color: '#333' } },
+            y: { ticks: { color: '#e0e0e0' }, grid: { color: '#333' } },
+          },
+          plugins: { legend: { labels: { color: '#e0e0e0' } } },
+        },
+      });
+    })
+    .catch((err) => console.error('Error loading habit success data:', err));
+}

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,0 +1,41 @@
+body {
+  background-color: #121212;
+  color: #e0e0e0;
+  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+  margin: 0;
+  padding: 20px;
+}
+
+header {
+  text-align: center;
+  margin-bottom: 20px;
+}
+
+button {
+  background-color: #1e88e5;
+  color: #fff;
+  border: none;
+  padding: 8px 16px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+button:hover {
+  background-color: #1565c0;
+}
+
+#habitList {
+  list-style: none;
+  padding: 0;
+  margin-top: 10px;
+}
+
+section {
+  margin-bottom: 40px;
+}
+
+canvas {
+  background: #1e1e1e;
+  padding: 10px;
+  border-radius: 4px;
+}


### PR DESCRIPTION
## Summary
- style frontend in dark mode and modular CSS/JS
- display habit list, daily success heatmap, and success rate charts

## Testing
- `python -m py_compile backend/routes/*.py backend/app.py backend/db_models.py`
- `node --check frontend/script.js`


------
https://chatgpt.com/codex/tasks/task_e_6895abee99b0832f808fbf2acf8bd7f9