### PR TITLE
feat: add signup flow and richer dashboard

### DIFF
--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -18,4 +18,4 @@ def register():
     db.session.add(new_user)
     db.session.commit()
 
-    return jsonify({"message": "User registered successfully!"}), 201
+    return jsonify({"message": "User registered successfully!", "user_id": new_user.id}), 201

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,8 +1,8 @@
 FROM nginx:alpine
 
-COPY index.html /usr/share/nginx/html/
+COPY index.html signup.html /usr/share/nginx/html/
 COPY styles.css /usr/share/nginx/html/
-COPY script.js /usr/share/nginx/html/
+COPY script.js signup.js /usr/share/nginx/html/
 
 
 EXPOSE 80

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,115 +1,49 @@
-
 <!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Habit Tracker</title>
-
-  <!-- cal-heatmap CSS -->
-  <link
-    href="https://cdn.jsdelivr.net/npm/cal-heatmap@4.4.0/cal-heatmap.css"
-    rel="stylesheet"
-  />
-  <style>
-    body {
-      font-family: Arial, sans-serif;
-      margin: 20px;
-    }
-    #habitList {
-      margin-top: 10px;
-      list-style: none;
-      padding-left: 0;
-    }
-    #habitList li {
-      padding: 4px 0;
-    }
-    #habit-heatmap {
-      margin-top: 40px;
-    }
-  </style>
+  <link rel="stylesheet" href="styles.css" />
+  <link href="https://cdn.jsdelivr.net/npm/cal-heatmap@4.4.0/cal-heatmap.css" rel="stylesheet" />
 </head>
 <body>
-  <h1>My Habits</h1>
-  <button onclick="loadHabits()">Load Habits</button>
-  <ul id="habitList"></ul>
+  <header>
+    <h1>Habit Tracker Dashboard</h1>
+  </header>
+  <main>
+    <section class="add-habit">
+      <h2>Add Habit</h2>
+      <form id="addHabitForm">
+        <input type="text" id="habitName" placeholder="Habit name" required />
+        <button type="submit">Add</button>
+      </form>
+    </section>
 
-  <h2>Habit Completion Heatmap</h2>
-  <div id="habit-heatmap"></div>
+    <section class="habits">
+      <h2>Your Habits</h2>
+      <ul id="habitList"></ul>
+    </section>
 
-  <!-- cal-heatmap JS -->
+    <section class="analytics">
+      <h2>Daily Success Rate</h2>
+      <div id="habit-heatmap"></div>
+      <canvas id="successChart"></canvas>
+    </section>
+
+    <section class="analytics">
+      <h2>Habit Success Rates</h2>
+      <canvas id="habitChart"></canvas>
+    </section>
+
+    <section class="analytics">
+      <h2>Best &amp; Worst Habit</h2>
+      <div id="bestWorst"></div>
+    </section>
+  </main>
+
   <script src="https://cdn.jsdelivr.net/npm/cal-heatmap@4.4.0/cal-heatmap.min.js"></script>
-  <script>
-    // Load habit list from backend
-    function loadHabits() {
-      fetch('http://localhost:5050/users/1/habits')
-        .then(response => response.json())
-        .then(data => {
-          const list = document.getElementById('habitList');
-          list.innerHTML = ''; // clear previous results
-          data.forEach(habit => {
-            const li = document.createElement('li');
-            li.textContent = habit.name;
-            list.appendChild(li);
-          });
-        })
-        .catch(err => {
-          console.error('Error loading habits:', err);
-        });
-    }
-
-    // Load and render heatmap of habit completion scores
-    function loadHeatmap() {
-      const cal = new CalHeatmap();
-
-      fetch("http://localhost:5050/users/1/scores")
-        .then(res => res.json())
-        .then(data => {
-          // Format data for cal-heatmap: keys are unix timestamps in seconds, values are intensity levels
-          const formatted = {};
-          data.forEach(entry => {
-            const timestamp = new Date(entry.date).getTime() / 1000;
-            // Map your score to heatmap intensity: 1 = no activity, 3 = full completion
-            formatted[timestamp] = entry.score === 1 ? 3 : (entry.score === 0 ? 2 : 1);
-          });
-
-          cal.paint({
-            itemSelector: "#habit-heatmap",
-            range: 12,
-            domain: {
-              type: "month",
-              gutter: 4
-            },
-            subDomain: {
-              type: "day",
-              radius: 4,
-              width: 20,
-              height: 20,
-            },
-            data: {
-              source: formatted,
-              type: "json"
-            },
-            scale: {
-              color: {
-                type: "linear",
-                domain: [1, 3],
-                range: ["#ebedf0", "#30a14e"] // GitHub-style colors
-              }
-            },
-            tooltip: true,
-          });
-        })
-        .catch(err => {
-          console.error('Error loading heatmap data:', err);
-        });
-    }
-
-    // Load heatmap on page load
-    window.onload = () => {
-      loadHeatmap();
-    };
-  </script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+  <script src="script.js"></script>
 </body>
 </html>
-

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -1,0 +1,184 @@
+const API_BASE = 'http://localhost:5050';
+let USER_ID = localStorage.getItem('userId');
+if (!USER_ID) {
+  window.location.href = 'signup.html';
+}
+
+let successChart;
+let habitChart;
+
+document.addEventListener('DOMContentLoaded', () => {
+  document
+    .getElementById('addHabitForm')
+    .addEventListener('submit', addHabit);
+  loadHabits();
+  loadHeatmap();
+  loadHabitSuccess();
+  loadBestWorst();
+});
+
+function loadHabits() {
+  fetch(`${API_BASE}/users/${USER_ID}/habits/status/today`)
+    .then((response) => response.json())
+    .then((data) => {
+      const list = document.getElementById('habitList');
+      list.innerHTML = '';
+      data.forEach((habit) => {
+        const li = document.createElement('li');
+        const label = document.createElement('label');
+        const checkbox = document.createElement('input');
+        checkbox.type = 'checkbox';
+        checkbox.checked = habit.checked;
+        checkbox.addEventListener('change', () =>
+          toggleHabit(habit.habit_id, checkbox.checked)
+        );
+        label.appendChild(checkbox);
+        label.appendChild(document.createTextNode(' ' + habit.name));
+        li.appendChild(label);
+        list.appendChild(li);
+      });
+    })
+    .catch((err) => console.error('Error loading habits:', err));
+}
+
+function toggleHabit(habitId, checked) {
+  fetch(`${API_BASE}/users/${USER_ID}/habits/${habitId}/checked`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ checked }),
+  })
+    .then(() => {
+      loadHabits();
+      loadHeatmap();
+      loadHabitSuccess();
+      loadBestWorst();
+    })
+    .catch((err) => console.error('Error toggling habit:', err));
+}
+
+function addHabit(e) {
+  e.preventDefault();
+  const name = document.getElementById('habitName').value.trim();
+  if (!name) return;
+  fetch(`${API_BASE}/users/${USER_ID}/habits`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name }),
+  })
+    .then((res) => {
+      if (!res.ok) {
+        return res.json().then((d) => {
+          throw new Error(d.error || 'Failed to add habit');
+        });
+      }
+      return res.json();
+    })
+    .then(() => {
+      document.getElementById('habitName').value = '';
+      loadHabits();
+      loadHeatmap();
+      loadHabitSuccess();
+      loadBestWorst();
+    })
+    .catch((err) => alert(err.message));
+}
+
+function loadBestWorst() {
+  fetch(`${API_BASE}/users/${USER_ID}/habits/best-worst`)
+    .then((res) => res.json())
+    .then((data) => {
+      const div = document.getElementById('bestWorst');
+      if (!data.best_habit) {
+        div.textContent = 'No habits yet.';
+      } else {
+        div.innerHTML = `<p><strong>Best:</strong> ${data.best_habit.name} (${data.best_habit.success_rate}%)</p>
+        <p><strong>Worst:</strong> ${data.worst_habit.name} (${data.worst_habit.success_rate}%)</p>`;
+      }
+    })
+    .catch((err) => console.error('Error loading best/worst habits:', err));
+}
+
+function loadHeatmap() {
+  const cal = new CalHeatmap();
+  document.getElementById('habit-heatmap').innerHTML = '';
+  fetch(`${API_BASE}/users/${USER_ID}/success-log`)
+    .then((res) => res.json())
+    .then((data) => {
+      if (data.length === 0) {
+        document.getElementById('habit-heatmap').textContent = 'No activity yet.';
+      } else {
+        const formatted = {};
+        data.forEach((entry) => {
+          const timestamp = new Date(entry.date).getTime() / 1000;
+          formatted[timestamp] = entry.success_rate;
+        });
+        cal.paint({
+          itemSelector: '#habit-heatmap',
+          range: 12,
+          domain: { type: 'month', gutter: 4 },
+          subDomain: { type: 'day', radius: 4, width: 20, height: 20 },
+          data: { source: formatted, type: 'json' },
+          scale: {
+            color: { type: 'linear', domain: [0, 100], range: ['#3a3a3a', '#81c784'] },
+          },
+          tooltip: true,
+        });
+      }
+
+      const ctx = document.getElementById('successChart').getContext('2d');
+      if (successChart) successChart.destroy();
+      successChart = new Chart(ctx, {
+        type: 'line',
+        data: {
+          labels: data.map((d) => d.date),
+          datasets: [
+            {
+              label: 'Daily Success Rate (%)',
+              data: data.map((d) => d.success_rate),
+              borderColor: '#1e88e5',
+              backgroundColor: 'rgba(30, 136, 229, 0.2)',
+              tension: 0.2,
+            },
+          ],
+        },
+        options: {
+          scales: {
+            x: { ticks: { color: '#e0e0e0' }, grid: { color: '#333' } },
+            y: { ticks: { color: '#e0e0e0' }, grid: { color: '#333' } },
+          },
+          plugins: { legend: { labels: { color: '#e0e0e0' } } },
+        },
+      });
+    })
+    .catch((err) => console.error('Error loading heatmap data:', err));
+}
+
+function loadHabitSuccess() {
+  fetch(`${API_BASE}/users/${USER_ID}/habits/success`)
+    .then((res) => res.json())
+    .then((data) => {
+      const ctx = document.getElementById('habitChart').getContext('2d');
+      if (habitChart) habitChart.destroy();
+      habitChart = new Chart(ctx, {
+        type: 'bar',
+        data: {
+          labels: data.map((h) => h.name),
+          datasets: [
+            {
+              label: 'Success Rate (%)',
+              data: data.map((h) => h.success_rate),
+              backgroundColor: '#1e88e5',
+            },
+          ],
+        },
+        options: {
+          scales: {
+            x: { ticks: { color: '#e0e0e0' }, grid: { color: '#333' } },
+            y: { ticks: { color: '#e0e0e0' }, grid: { color: '#333' } },
+          },
+          plugins: { legend: { labels: { color: '#e0e0e0' } } },
+        },
+      });
+    })
+    .catch((err) => console.error('Error loading habit success data:', err));
+}

--- a/frontend/signup.html
+++ b/frontend/signup.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Sign Up - Habit Tracker</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <main class="signup">
+    <h1>Create Account</h1>
+    <form id="signupForm">
+      <input type="text" id="username" placeholder="Username" required />
+      <input type="password" id="password" placeholder="Password" required />
+      <button type="submit">Sign Up</button>
+    </form>
+  </main>
+  <script src="signup.js"></script>
+</body>
+</html>

--- a/frontend/signup.js
+++ b/frontend/signup.js
@@ -1,0 +1,27 @@
+const API_BASE = 'http://localhost:5050';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('signupForm');
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const username = document.getElementById('username').value;
+    const password = document.getElementById('password').value;
+    try {
+      const res = await fetch(`${API_BASE}/register`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password }),
+      });
+      const data = await res.json();
+      if (res.ok) {
+        localStorage.setItem('userId', data.user_id);
+        window.location.href = 'index.html';
+      } else {
+        alert(data.error || 'Registration failed');
+      }
+    } catch (err) {
+      console.error('Registration error:', err);
+      alert('Registration failed');
+    }
+  });
+});

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,0 +1,76 @@
+body {
+  background-color: #121212;
+  color: #e0e0e0;
+  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+  margin: 0;
+  padding: 20px;
+}
+
+header {
+  text-align: center;
+  margin-bottom: 20px;
+}
+
+button {
+  background-color: #1e88e5;
+  color: #fff;
+  border: none;
+  padding: 8px 16px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+button:hover {
+  background-color: #1565c0;
+}
+
+#habitList li {
+  margin: 4px 0;
+}
+
+#habit-heatmap {
+  margin-top: 20px;
+}
+
+input[type="text"],
+input[type="password"] {
+  padding: 8px;
+  border-radius: 4px;
+  border: 1px solid #555;
+  background: #1e1e1e;
+  color: #e0e0e0;
+}
+
+.signup {
+  text-align: center;
+  margin-top: 60px;
+}
+
+.signup form {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-width: 300px;
+  margin: 0 auto;
+}
+
+#addHabitForm {
+  display: flex;
+  gap: 10px;
+}
+
+#habitList {
+  list-style: none;
+  padding: 0;
+  margin-top: 10px;
+}
+
+section {
+  margin-bottom: 40px;
+}
+
+canvas {
+  background: #1e1e1e;
+  padding: 10px;
+  border-radius: 4px;
+}


### PR DESCRIPTION
## Summary
- allow registration to return the new user id and serve signup assets
- build signup page with client script that saves user id and redirects to dashboard
- extend dashboard with habit creation, daily toggles, and best/worst analytics

## Testing
- `python -m py_compile backend/routes/*.py backend/app.py backend/db_models.py`
- `node --check frontend/script.js frontend/signup.js`


------
https://chatgpt.com/codex/tasks/task_e_6895abee99b0832f808fbf2acf8bd7f9